### PR TITLE
Bugfix android crash

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -960,8 +960,6 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onPlayerError(ExoPlaybackException e) {
-        Log.e(TAG, e.getCause().getMessage());
-
         String errorString = null;
         String errorDomain = null;
         int errorCode = 0;
@@ -1008,7 +1006,10 @@ class ReactExoplayerView extends FrameLayout implements
                 errorString = e.getLocalizedMessage();
             }
         }
-        eventEmitter.error(errorCode, errorString, errorDomain);
+        if (errorString != null) {
+            Log.e(TAG, errorString);
+            eventEmitter.error(errorCode, errorString, errorDomain);
+        }
         playerNeedsSource = true;
         if (isBehindLiveWindow(e)) {
             clearResumePosition();


### PR DESCRIPTION
#### Describe the changes
solve this crash [error](https://play.google.com/apps/publish/?account=5638322997565197616#AndroidMetricsErrorsPlace:p=com.soundwisecms_mobile_android&appid=4976217210514928899&appVersion=PRODUCTION&installSource=INSTALLED_FROM_ANYWHERE&clusterName=apps/com.soundwisecms_mobile_android/clusters/a4571664&detailsAppVersion=PRODUCTION&detailsSpan=7&detailsInstallSource=INSTALLED_FROM_ANYWHERE)
```
java.lang.NullPointerException: 
  at android.util.Log.println_native (Native Method)
  at android.util.Log.e (Log.java:249)
  at com.brentvatne.exoplayer.ReactExoplayerView.onPlayerError (ReactExoplayerView.java:963)
  at com.google.android.exoplayer2.ExoPlayerImpl$PlaybackInfoUpdate.lambda$run$2$ExoPlayerImpl$PlaybackInfoUpdate (ExoPlayerImpl.java:812)
  at com.google.android.exoplayer2.-$$Lambda$ExoPlayerImpl$PlaybackInfoUpdate$fI_Ao37C4zouOtNaX7xHdRfgmVc.invokeListener (Unknown Source:2)
  at com.google.android.exoplayer2.BasePlayer$ListenerHolder.invoke (BasePlayer.java:182)
  at com.google.android.exoplayer2.ExoPlayerImpl.invokeAll (ExoPlayerImpl.java:845)
  at com.google.android.exoplayer2.ExoPlayerImpl.access$000 (ExoPlayerImpl.java:43)
  at com.google.android.exoplayer2.ExoPlayerImpl$PlaybackInfoUpdate.run (ExoPlayerImpl.java:812)
  at com.google.android.exoplayer2.ExoPlayerImpl.notifyListeners (ExoPlayerImpl.java:736)
  at com.google.android.exoplayer2.ExoPlayerImpl.updatePlaybackInfo (ExoPlayerImpl.java:710)
  at com.google.android.exoplayer2.ExoPlayerImpl.handlePlaybackInfo (ExoPlayerImpl.java:652)
  at com.google.android.exoplayer2.ExoPlayerImpl.handleEvent (ExoPlayerImpl.java:595)
  at com.google.android.exoplayer2.ExoPlayerImpl$1.handleMessage (ExoPlayerImpl.java:127)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:7356)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:492)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:930)
```